### PR TITLE
fix: indexedentity availibility

### DIFF
--- a/ios/Classes/IntelligenceSearchableItems.swift
+++ b/ios/Classes/IntelligenceSearchableItems.swift
@@ -6,8 +6,10 @@ import MobileCoreServices
 
 @available(iOS 18.0, *)
 public class IntelligenceSearchableItems {
+  @available(iOS 18.0, *)
   var mapper: ((_ item: IntelligenceItem) -> any IndexedEntity)?
 
+  @available(iOS 18.0, *)
   public func attachEntityMapper(mapper: @escaping (_ item: (id: String, representation: String)) -> any IndexedEntity) {
     self.mapper = mapper
   }

--- a/ios/Classes/RepresentableEntity.swift
+++ b/ios/Classes/RepresentableEntity.swift
@@ -15,6 +15,7 @@ struct RepresentableEntity: AppEntity {
   let representation: String
 }
 
+@available(iOS 18.0, *)
 extension RepresentableEntity: IndexedEntity {
   var attributeSet: CSSearchableItemAttributeSet {
     let attributes = CSSearchableItemAttributeSet()


### PR DESCRIPTION
2024-10-21T17:49:20.5809600Z Failed to build iOS app
2024-10-21T17:49:20.5866710Z Swift Compiler Error (Xcode): Cannot find type 'IndexedEntity' in scope
2024-10-21T17:49:20.5867890Z /Users/runner/.pub-cache/hosted/pub.dev/intelligence-0.0.1-dev.2/ios/Classes/IntelligenceSearchableItems.swift:8:49
2024-10-21T17:49:20.5868280Z 
2024-10-21T17:49:20.5869220Z Swift Compiler Error (Xcode): Cannot find type 'IndexedEntity' in scope
2024-10-21T17:49:20.5870090Z /Users/runner/.pub-cache/hosted/pub.dev/intelligence-0.0.1-dev.2/ios/Classes/IntelligenceSearchableItems.swift:10:105
2024-10-21T17:49:20.5870360Z 
2024-10-21T17:49:20.5870780Z Swift Compiler Error (Xcode): Cannot find type 'IndexedEntity' in scope
2024-10-21T17:49:20.5871410Z /Users/runner/.pub-cache/hosted/pub.dev/intelligence-0.0.1-dev.2/ios/Classes/RepresentableEntity.swift:17:31

fixes #1 